### PR TITLE
Ignore pioneer-opt-in/ directory in git and ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ addon/PioneerUtils.jsm
 firefox
 # don't lint/format package.json since npm install formats it differently by default
 package.json
+pioneer-opt-in

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ addon/StudyUtils.jsm
 addon/PioneerUtils.jsm
 screenshot.png
 pings.json
+pioneer-opt-in

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pioneer",
     "shield-study"
   ],
-  "license": "ISC",
+  "license": "MPL-2.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -42,17 +42,17 @@
     "npm-run-all": "^4.1.1",
     "nsp": "^2.8.1",
     "onchange": "^3.2.1",
+    "pioneer-utils": "^1.0.10",
     "prettier": "^1.10.2",
-    "selenium-webdriver": "^3.5.0",
-    "pioneer-utils": "^1.0.10"
+    "selenium-webdriver": "^3.5.0"
   },
   "homepage": "https://github.com/motin/esper-pioneer-shield-study",
   "keywords": [
-    "mozilla",
-    "legacy-addon",
     "firefox",
-    "shield-study",
-    "pioneer"
+    "legacy-addon",
+    "mozilla",
+    "pioneer",
+    "shield-study"
   ],
   "license": "ISC",
   "main": "index.js",
@@ -63,13 +63,13 @@
   "scripts": {
     "build": "bash ./bin/xpi.sh",
     "eslint": "eslint . --ext jsm --ext js --ext json",
-    "eslint-fix": "eslint . --ext jsm --ext js --ext json --fix",
+    "eslint-fix": "npm run eslint -- --fix",
     "firefox": "export XPI=dist/linked-addon.xpi && npm run build && node run-firefox.js",
     "format": "prettier '**/*.{css,js,json,jsm,md}' --trailing-comma=all --ignore-path=.eslintignore --write && npm run eslint-fix",
     "harness_test": "export XPI=dist/linked-addon.xpi && mocha test/functional_tests.js --retry 2 --reporter json",
     "lint": "npm-run-all lint:*",
     "lint-build:addons-linter": "# actually a post build test:  bin/addonLintTest ' + require('./package.json').name",
-    "lint:addons-linter": "addons-linter addon/webextension/",
+    "lint:addons-linter": "addons-linter addon",
     "lint:eslint": "npm run eslint",
     "lint:fixpack": "fixpack",
     "lint:nsp": "nsp check",


### PR DESCRIPTION
Seems to be a git clone of an [external repo](https://github.com/mozilla/pioneer-opt-in):

https://github.com/motin/esper-pioneer-shield-study/blob/e895319ea4f35edbe29de525082a587a0a61623c/bin/xpi.sh#L46-L53
